### PR TITLE
Fix bug causing the middleware to never work

### DIFF
--- a/src/PrerenderMiddleware.php
+++ b/src/PrerenderMiddleware.php
@@ -142,8 +142,10 @@ class PrerenderMiddleware
         }
 
         // prerender if a crawler is detected
-        if (in_array(strtolower($userAgent), $this->crawlerUserAgents)) {
-            $isRequestingPrerenderedPage = true;
+        foreach ($this->crawlerUserAgents as $crawlerUserAgent) {
+            if (Str::contains($userAgent, strtolower($crawlerUserAgent))) {
+                $isRequestingPrerenderedPage = true;
+            }
         }
 
         if ($bufferAgent) {


### PR DESCRIPTION
Without this change, the middleware would consider a request as "requesting pre-rendered page" only when the User Agent was exactly the same as one of the "crawler user agents" specified in the config file.
This is a bug because, typically, the User Agent of a crawler is not just one word.

Example of one of the Googlebot's User Agents:
`Googlebot/2.1 (+http://www.google.com/bot.html)`

I'd ask you to please tag a new release.