### PR TITLE
Add Guzzle Timeout To Prerender Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,21 @@ return [
         'Qwantify'
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Timeout
+    |--------------------------------------------------------------------------
+    |
+    | Specifies the Guzzle request timeout in seconds. If the request for a
+    | prerendered page takes longer than this, the request will be terminated
+    | and the page will be loaded without prerender. A value of 0 means no
+    | timeout.
+    |
+    | See: https://docs.guzzlephp.org/en/stable/request-options.html#timeout
+    |
+    */
+    'timeout' => env('PRERENDER_TIMEOUT', 0),
+
 ];
 ```
 

--- a/config/prerender.php
+++ b/config/prerender.php
@@ -181,4 +181,19 @@ return [
         'Qwantify',
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Timeout
+    |--------------------------------------------------------------------------
+    |
+    | Specifies the Guzzle request timeout in seconds. If the request for a
+    | prerendered page takes longer than this, the request will be terminated
+    | and the page will be loaded without prerender. A value of 0 means no
+    | timeout.
+    |
+    | See: https://docs.guzzlephp.org/en/stable/request-options.html#timeout
+    |
+    */
+    'timeout' => env('PRERENDER_TIMEOUT', 0),
+
 ];

--- a/tests/PrerenderMiddlewareTest.php
+++ b/tests/PrerenderMiddlewareTest.php
@@ -2,6 +2,8 @@
 
 namespace CodebarAg\LaravelPrerender\Tests;
 
+use GuzzleHttp\Client;
+
 class PrerenderMiddlewareTest extends TestCase
 {
     /** @test */
@@ -74,6 +76,20 @@ class PrerenderMiddlewareTest extends TestCase
     public function it_should_not_prerender_page_when_missing_user_agent()
     {
         $this->get('/test-middleware', ['User-Agent' => null])
+            ->assertHeaderMissing('prerender.io-mock')
+            ->assertSee('GET - Success');
+    }
+
+    /** @test */
+    public function it_should_not_prerender_page_if_request_times_out()
+    {
+        $this->app->bind(Client::class, function () {
+            return $this->createMockTimeoutClient();
+        });
+
+        $this->allowSymfonyUserAgent();
+
+        $this->get('/test-middleware')
             ->assertHeaderMissing('prerender.io-mock')
             ->assertSee('GET - Success');
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,8 +5,10 @@ namespace CodebarAg\LaravelPrerender\Tests;
 use CodebarAg\LaravelPrerender\LaravelPrerenderServiceProvider;
 use CodebarAg\LaravelPrerender\PrerenderMiddleware;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Http\Kernel;
@@ -47,6 +49,17 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
             return new Client(['handler' => $stack]);
         });
+    }
+
+    protected function createMockTimeoutClient(): Client
+    {
+        $mock = new MockHandler([
+            new ConnectException('Could not connect', new Request('GET', 'test')),
+        ]);
+
+        $stack = HandlerStack::create($mock);
+
+        return new Client(['handler' => $stack]);
     }
 
     protected function setupRoutes(): void


### PR DESCRIPTION
Implementation for #38 

Since the constructor was already updating guzzle config for `allow_redirects`, I decided to use the same idea for `timeout`. *Potentially* a breaking change since a new Guzzle client is created every time now, although I doubt that's too significant? I've also maintained throwing exceptions in debug mode for both `RequestException` and the new `ConnectException`

Ran `composer format` which added a few extra small whitespace changes. Let me know if the additional test and readme changes are enough