### PR TITLE
Send Entire Request, Including Query Params, To Prerender

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,21 @@ return [
     | See: https://docs.guzzlephp.org/en/stable/request-options.html#timeout
     |
     */
+
     'timeout' => env('PRERENDER_TIMEOUT', 0),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Timeout
+    |--------------------------------------------------------------------------
+    |
+    | By default, request query parameters are not sent to prerender when
+    | requesting the prerendered page. Setting this to true will cause the full
+    | URL, including query parameters, to be sent to prerender.
+    |
+    */
+
+    'full_url' => env('PRERENDER_FULL_URL', false),
 
 ];
 ```

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Timeout
+    | Query Parameters
     |--------------------------------------------------------------------------
     |
     | By default, request query parameters are not sent to prerender when

--- a/config/prerender.php
+++ b/config/prerender.php
@@ -194,6 +194,20 @@ return [
     | See: https://docs.guzzlephp.org/en/stable/request-options.html#timeout
     |
     */
+
     'timeout' => env('PRERENDER_TIMEOUT', 0),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Timeout
+    |--------------------------------------------------------------------------
+    |
+    | By default, request query parameters are not sent to prerender when
+    | requesting the prerendered page. Setting this to true will cause the full
+    | URL, including query parameters, to be sent to prerender.
+    |
+    */
+
+    'full_url' => env('PRERENDER_FULL_URL', false),
 
 ];

--- a/config/prerender.php
+++ b/config/prerender.php
@@ -199,7 +199,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Timeout
+    | Query Parameters
     |--------------------------------------------------------------------------
     |
     | By default, request query parameters are not sent to prerender when

--- a/src/PrerenderMiddleware.php
+++ b/src/PrerenderMiddleware.php
@@ -195,18 +195,8 @@ class PrerenderMiddleware
             $headers['X-Prerender-Token'] = $this->prerenderToken;
         }
 
-        $protocol = $request->isSecure() ? 'https' : 'http';
-
         try {
-            // Return the Guzzle Response
-            $host = $request->getHost();
-            $path = $request->Path();
-            // Fix "//" 404 error
-            if ($path === '/') {
-                $path = '';
-            }
-
-            return $this->client->get($this->prerenderUri.'/'.urlencode($protocol.'://'.$host.'/'.$path), compact('headers'));
+            return $this->client->get($this->prerenderUri.'/'.urlencode($request->fullUrl()), compact('headers'));
         } catch (RequestException $exception) {
             if (!$this->returnSoftHttpCodes && !empty($exception->getResponse()) && $exception->getResponse()->getStatusCode() === 404) {
                 abort(404);

--- a/src/PrerenderMiddleware.php
+++ b/src/PrerenderMiddleware.php
@@ -66,6 +66,13 @@ class PrerenderMiddleware
     private $returnSoftHttpCodes;
 
     /**
+     * Send the full request URL to prerender.
+     *
+     * @var bool
+     */
+    private $useFullURL;
+
+    /**
      * Creates a new PrerenderMiddleware instance.
      */
     public function __construct(Guzzle $client)
@@ -88,6 +95,7 @@ class PrerenderMiddleware
         $this->prerenderToken = $config['prerender_token'];
         $this->whitelist = $config['whitelist'];
         $this->blacklist = $config['blacklist'];
+        $this->useFullURL = $config['full_url'];
     }
 
     /**
@@ -196,7 +204,9 @@ class PrerenderMiddleware
         }
 
         try {
-            return $this->client->get($this->prerenderUri.'/'.urlencode($request->fullUrl()), compact('headers'));
+            $url = $this->generatePrerenderUrl($request);
+
+            return $this->client->get($this->prerenderUri.'/'.urlencode($url), compact('headers'));
         } catch (RequestException $exception) {
             if (!$this->returnSoftHttpCodes && !empty($exception->getResponse()) && $exception->getResponse()->getStatusCode() === 404) {
                 abort(404);
@@ -239,5 +249,27 @@ class PrerenderMiddleware
         }
 
         return false;
+    }
+
+    /**
+     * Generate the request URL to send to prerender. When useFullURL is false, the legacy URL
+     * generation logic is used
+     */
+    private function generatePrerenderUrl(Request $request): string
+    {
+        if ($this->useFullURL) {
+            return $request->fullUrl();
+        }
+
+        $protocol = $request->isSecure() ? 'https' : 'http';
+        $host = $request->getHost();
+        $path = $request->Path();
+
+        // Fix "//" 404 error
+        if ($path === '/') {
+            $path = '';
+        }
+
+        return $protocol.'://'.$host.'/'.$path;
     }
 }

--- a/tests/PrerenderMiddlewareTest.php
+++ b/tests/PrerenderMiddlewareTest.php
@@ -94,6 +94,21 @@ class PrerenderMiddlewareTest extends TestCase
             ->assertSee('GET - Success');
     }
 
+    /** @test */
+    public function it_sends_full_query_string_to_prerender()
+    {
+        $this->app->bind(Client::class, function () {
+            return $this->createMockUrlTrackingClient();
+        });
+
+        $this->allowSymfonyUserAgent();
+
+        $this->get('/test-middleware?withQueryParam=true')
+            ->assertHeader('prerender.io-mock', true)
+            ->assertSuccessful()
+            ->assertSee(urlencode('/test-middleware?withQueryParam=true'));
+    }
+
     private function allowSymfonyUserAgent()
     {
         config()->set('prerender.crawler_user_agents', ['symfony']);

--- a/tests/PrerenderMiddlewareTest.php
+++ b/tests/PrerenderMiddlewareTest.php
@@ -95,7 +95,7 @@ class PrerenderMiddlewareTest extends TestCase
     }
 
     /** @test */
-    public function it_sends_full_query_string_to_prerender()
+    public function it_does_not_send_query_strings_to_prerender_by_default()
     {
         $this->app->bind(Client::class, function () {
             return $this->createMockUrlTrackingClient();
@@ -106,11 +106,33 @@ class PrerenderMiddlewareTest extends TestCase
         $this->get('/test-middleware?withQueryParam=true')
             ->assertHeader('prerender.io-mock', true)
             ->assertSuccessful()
+            ->assertSee(urlencode('/test-middleware'))
+            ->assertDontSee('withQueryParam');
+    }
+
+    /** @test */
+    public function it_sends_full_query_string_to_prerender()
+    {
+        $this->app->bind(Client::class, function () {
+            return $this->createMockUrlTrackingClient();
+        });
+
+        $this->allowSymfonyUserAgent();
+        $this->allowQueryParams();
+
+        $this->get('/test-middleware?withQueryParam=true')
+            ->assertHeader('prerender.io-mock', true)
+            ->assertSuccessful()
             ->assertSee(urlencode('/test-middleware?withQueryParam=true'));
     }
 
     private function allowSymfonyUserAgent()
     {
         config()->set('prerender.crawler_user_agents', ['symfony']);
+    }
+
+    private function allowQueryParams()
+    {
+        config()->set('prerender.full_url', true);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Psr7\Response;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Http\Kernel;
 use Illuminate\Support\Facades\Route;
+use Psr\Http\Message\RequestInterface;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
@@ -55,6 +56,23 @@ class TestCase extends \Orchestra\Testbench\TestCase
     {
         $mock = new MockHandler([
             new ConnectException('Could not connect', new Request('GET', 'test')),
+        ]);
+
+        $stack = HandlerStack::create($mock);
+
+        return new Client(['handler' => $stack]);
+    }
+
+    protected function createMockUrlTrackingClient(): Client
+    {
+        $mock = new MockHandler([
+            function (RequestInterface $request) {
+                return new Response(
+                    200,
+                    ['prerender.io-mock' => true],
+                    (string) $request->getUri()
+                );
+            },
         ]);
 
         $stack = HandlerStack::create($mock);


### PR DESCRIPTION
### Problem
Prerender accepts query params and allows them to influence the prerendered page content, see [https://docs.prerender.io/docs/ignore-config](https://docs.prerender.io/docs/ignore-config). Some applications require this behavior

### Solution
Send the query params along in the prerendered request

This behavior was removed in the previous version of this repository here https://github.com/jeroennoten/Laravel-Prerender/pull/9. It's not exactly clear to me how this solves an ELB http/https issue, as `fullUrl()` likewise differentiates between the two using `$request->isSecure()`, so I'm not sure how or if this would reintroduce that issue

The only other change this makes is that when requesting the page at `/`, the new logic no longer sends a trailing slash (something like `https://service.prerender.io/http%3A%2F%2Flocalhost` rather than `https://service.prerender.io/http%3A%2F%2Flocalhost%2F`). All other urls should remain the same, with the exception of query params

If either of these may be an issue, we could also append the query string to the prexisting logic with `$request->getQueryString()` instead of using `fullUrl()`, I just figured the latter would be simpler